### PR TITLE
Rewrite LLM-generated SDL posts: de-anthropomorphize and de-cutesify

### DIFF
--- a/sdl-adventure-game/_posts/2026-06-29-fixing-the-bugs-a-code-review-found.markdown
+++ b/sdl-adventure-game/_posts/2026-06-29-fixing-the-bugs-a-code-review-found.markdown
@@ -10,7 +10,7 @@ the [AI-assisted code review]({% post_url sdl-adventure-game/2025-01-17-ai-power
 I've leaned on before — this time file by file, all the way through `main.c`,
 `game.c`, `asset.c`, `actor.c`, `image.c`, `sound.c`, and `scene.c`.
 
-## A backlog, first
+## Triaging the review before fixing anything
 
 The review came back long, so before changing anything I triaged it into the
 backlog. That step matters more than it sounds: a review mixes real crashes with
@@ -20,7 +20,7 @@ because the calls happen to run in sequence. Sorting the genuine bugs from the
 nice-to-haves left a short, honest list of things actually worth fixing. Then I
 picked the top of it.
 
-## One callback for everyone
+## A global walk-end callback, shared by every actor
 
 The clearest bug was a single line:
 
@@ -31,12 +31,12 @@ static void (*on_end_walking)(void);
 That's the "what to do when the character finishes walking" callback — and it was
 a *global*. With one actor on screen it works. With two, the second
 `actor_walk_to` overwrites the first's callback, and when the fox arrives it runs
-the hen's errand instead of its own. It's the classic C single-global-callback
+the hen's callback instead of its own. It's the classic C single-global-callback
 trap, and it had quietly survived the whole move to a generic actor. The fix is to
 put the callback on the `Actor` itself, and to clear it *before* firing it, so a
 callback that kicks off a new walk doesn't get immediately overwritten.
 
-## One halt too many
+## Mix_HaltChannel(-1) halts every channel
 
 The next one is the kind of bug that only shows up with a toddler holding the
 device. When an actor stops walking, the engine halts its footstep sound:
@@ -52,7 +52,7 @@ means **halt every channel**: the music, the dialogue, all of it. So in exactly
 the moment a two-year-old is mashing the screen, the voice line cuts out. Guarding
 the call with `channel >= 0` keeps a stray stop from taking down the whole mixer.
 
-## The smaller sharp edges
+## Smaller bugs: NaN heading, 32-bit overflow, NULL guards
 
 A few more, each small on its own:
 
@@ -69,7 +69,7 @@ A few more, each small on its own:
   are one-line guards; both are the sort of thing that never happens until it does,
   on the audio thread, in the browser.
 
-## The fix I had to back out
+## The coordinate fix I reverted
 
 The headline item from the review was a real one: mouse coordinates come in as
 *window* pixels, but every hotspot in the game is defined in the *logical* 800×600

--- a/sdl-adventure-game/_posts/2026-07-01-where-should-an-animation-update-itself.markdown
+++ b/sdl-adventure-game/_posts/2026-07-01-where-should-an-animation-update-itself.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Where Should an Animation Update Itself?"
+title: "Moving Animation Timing from Render to Update"
 layout: post
 ---
 
@@ -65,7 +65,7 @@ one-shot in an off-screen scene could reach its end and fire its callback while 
 completely different scene is showing. That's a real cross-scene footgun hiding
 behind a convenient API. Convenient and wrong.
 
-## Second take: let the framework own it
+## Second take: the framework ticks the active scene's animations
 
 The right answer was already sitting in the codebase; I'd just failed to notice the
 pattern I'd been following everywhere else. A scene doesn't manage its own

--- a/sdl-adventure-game/_posts/2026-07-02-testing-the-game-in-a-terminal.markdown
+++ b/sdl-adventure-game/_posts/2026-07-02-testing-the-game-in-a-terminal.markdown
@@ -17,7 +17,7 @@ back to: a headless test target. The terminal build already does the hard part �
 before `SDL_Init` it sets `SDL_VIDEODRIVER=offscreen` and creates a **software**
 renderer, so every frame is drawn into an ordinary RGBA buffer instead of onto a
 screen ([the original change](https://github.com/potomak/VaniaVolpe/commit/c3eefe2)).
-Nothing about the game logic knows or cares. So a test is just: script some
+Nothing about the game logic depends on it. So a test is just: script some
 clicks, run the loop, and check the game did what it should.
 
 I already had a version of this for the web build — a small Puppeteer script that
@@ -35,14 +35,14 @@ list of mouse clicks straight onto SDL's event queue — the game's
 and state transition runs exactly as it does for a player.
 
 Then it checks the game *did the adventure*. Rather than compare screenshots, it
-watches what the game says — "Ho preso gli occhialini!", "Cestino pieno d'uva!",
+reads the dialogue the game logs — "Ho preso gli occhialini!", "Cestino pieno d'uva!",
 "Ecco il tuo salvagente!" — and asserts those lines appear in order, from the hub
 all the way to the dive. If one is missing, it reports which and exits non-zero.
 It also reads one frame back with `SDL_RenderReadPixels` and checks it isn't a
 single flat colour, a cheap way to catch the classic "black screen / missing
 texture" regression without pinning down exact pixels.
 
-## Capturing what the game says
+## Capturing the game's dialogue output
 
 That part took two goes. In the first version the game printed its dialogue with
 `printf`, so the harness just redirected its own stdout to a file with `freopen`,

--- a/sdl-adventure-game/_posts/2026-07-04-walking-around-things.md
+++ b/sdl-adventure-game/_posts/2026-07-04-walking-around-things.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Walking Around Things"
+title: "Pathfinding Around Obstacles with a Walk Grid and A*"
 ---
 
 The oldest documented limitation in VaniaVolpe was that the fox walks in a
@@ -9,8 +9,8 @@ sandbox, the slide, whatever the scene says is not ground. It had its own
 design note (`MOVEMENT.md`) written mostly so the problem wouldn't be
 forgotten, and the note ended with "keep the engine simple until this becomes
 a felt gameplay problem." It became one. This is the story of the fix: a
-walkability bitmap, A*, and a handful of places where the game deliberately
-disagrees with its own geometry.
+walkability bitmap, A*, and a handful of places where the routing deliberately
+allows illegal points.
 
 ![The straight line cuts through the slide; the routed path goes around it.](/sdl-adventure-game/assets/movement-before-after.png)
 
@@ -105,7 +105,7 @@ points and the old `actor_walk_to()` is just the one-point case. Between
 segments the walk animation and the footstep loop keep running, so a routed
 walk reads as one continuous motion with a couple of turns in it.
 
-## Where the game disagrees with its own geometry
+## Intentional exceptions: illegal starts and goals
 
 The pleasant surprise was how few special cases the scenes needed — and how
 honest the two real ones are.
@@ -157,5 +157,5 @@ wall — and the routed path passes it, waypoint by waypoint.
 
 Next on this thread: painting walkable masks in-game instead of typing
 rectangles (the grid is already a bitmap; it may as well be drawn), and
-scene-sized grids once scrolling scenes and a camera arrive. The fox, for
-now, walks around things.
+scene-sized grids once scrolling scenes and a camera arrive. For now, routed
+walks avoid obstacles instead of clipping through them.

--- a/sdl-adventure-game/_posts/2026-07-04-walking-around-things.md
+++ b/sdl-adventure-game/_posts/2026-07-04-walking-around-things.md
@@ -12,7 +12,7 @@ a felt gameplay problem." It became one. This is the story of the fix: a
 walkability bitmap, A*, and a handful of places where the routing deliberately
 allows illegal points.
 
-![The straight line cuts through the slide; the routed path goes around it.](/sdl-adventure-game/assets/movement-before-after.png)
+![The straight line cuts through the slide; the routed path goes around it.]({{ '/sdl-adventure-game/assets/movement-before-after.png' | relative_url }})
 
 ## Moving the endpoint doesn't move the path
 
@@ -97,7 +97,7 @@ line-of-sight pass — from each point, jump to the furthest path point whose
 connecting segment samples clean every 5 px — collapses those 56 points into
 3 waypoints:
 
-![The raw 56-point cell path and the 3-waypoint smoothed path it becomes.](/sdl-adventure-game/assets/movement-smoothing.png)
+![The raw 56-point cell path and the 3-waypoint smoothed path it becomes.]({{ '/sdl-adventure-game/assets/movement-smoothing.png' | relative_url }})
 
 The [generic actor]({% post_url /sdl-adventure-game/2026-06-24-an-engine-for-multiple-adventures %})
 grew a matching queue: `actor_walk_path()` accepts up to eight
@@ -125,7 +125,7 @@ inside the blocked rectangle around the structure; the router snaps the start
 the same way and she walks back out legally.
 
 And while rewriting `actor_walk_to` I found a bug in the
-[walk-then-do callbacks](/sdl-adventure-game/2025/01/21/chain-of-actions.html):
+[walk-then-do callbacks]({% post_url /sdl-adventure-game/2025-01-21-chain-of-actions %}):
 start a walk toward the slide, then tap the fox herself, and the pending
 "use the slide" callback survived the interruption
 and fired on the next frame — from wherever she stood. With the slide already

--- a/sdl-adventure-game/_posts/2026-07-05-the-fox-learns-to-talk.md
+++ b/sdl-adventure-game/_posts/2026-07-05-the-fox-learns-to-talk.md
@@ -4,7 +4,7 @@ title: "Lip-Sync from Offline-Generated Mouth Cues"
 ---
 
 Vania's dialogue audio has played since
-[January 2025](/sdl-adventure-game/2025/01/22/music-sound-effects-and-dialogs.html):
+[January 2025]({% post_url /sdl-adventure-game/2025-01-22-music-sound-effects-and-dialogs %}):
 play the line's WAV, loop a three-frame talking animation for exactly as long
 as the audio lasts, done. It worked, but it was the same mouth-flapping loop
 whether the line was "Evviva!" or a two-sentence hint about the squirrel — and
@@ -47,7 +47,7 @@ One thing the spec got wrong and the real recordings corrected: Rhubarb
 doesn't always close a file with a rest cue, so the generator treats the WAV's
 own duration as the end of the last speech span.
 
-![The gate line's waveform, its mouth cues, and the estimated word timing.](/sdl-adventure-game/assets/speech-cue-timeline.png)
+![The gate line's waveform, its mouth cues, and the estimated word timing.]({{ '/sdl-adventure-game/assets/speech-cue-timeline.png' | relative_url }})
 
 That figure is real data: the waveform of "Il cancello è chiuso…", the cue
 track Rhubarb heard in it, and a third row I'll get to at the end.
@@ -67,7 +67,7 @@ rectangle. The fox has three drawn mouths: closed, open, and a small round
 one. The new `talking.anim` is seven lines mapping the seven shapes onto
 those three drawings:
 
-![The three drawn mouths and which canonical shapes reuse each one.](/sdl-adventure-game/assets/speech-three-mouths.png)
+![The three drawn mouths and which canonical shapes reuse each one.]({{ '/sdl-adventure-game/assets/speech-three-mouths.png' | relative_url }})
 
 It's crude — E and F deserve their own pucker eventually — but the effect is
 immediate: the mouth shuts during pauses and between sentences, opens on the
@@ -93,7 +93,7 @@ for now), fall back to the exact looping behaviour the game has had since
 January.
 
 The parsers are deliberately strict, a lesson learned from the
-[`.anim` parser](/sdl-adventure-game/2025/01/17/parsing-animation-metadata.html)
+[`.anim` parser]({% post_url /sdl-adventure-game/2025-01-17-parsing-animation-metadata %})
 that accepted its input without validation: out-of-order timestamps, unknown
 letters, oversized files, truncated lines — any of it rejects the whole sidecar
 loudly, and the line degrades to the legacy loop instead of half-working.

--- a/sdl-adventure-game/_posts/2026-07-05-the-fox-learns-to-talk.md
+++ b/sdl-adventure-game/_posts/2026-07-05-the-fox-learns-to-talk.md
@@ -1,18 +1,19 @@
 ---
 layout: post
-title: "The Fox Learns to Talk"
+title: "Lip-Sync from Offline-Generated Mouth Cues"
 ---
 
-Vania has been talking since
+Vania's dialogue audio has played since
 [January 2025](/sdl-adventure-game/2025/01/22/music-sound-effects-and-dialogs.html):
 play the line's WAV, loop a three-frame talking animation for exactly as long
 as the audio lasts, done. It worked, but it was the same mouth-flapping loop
-whether she was saying "Evviva!" or delivering a two-sentence hint about the
-squirrel — and it kept flapping straight through her pauses. This week she
-learned to move her mouth with the words. The problem split into two halves,
-and it turned out someone had already solved the harder one.
+whether the line was "Evviva!" or a two-sentence hint about the squirrel — and
+it kept flapping straight through the pauses in the audio. This week the talking
+animation was updated to follow the mouth shapes in the spoken line, instead of
+looping on a timer. The problem split into two halves, and the harder one had
+already been solved by an existing tool.
 
-## Someone already solved the hard half
+## Offline lip-sync generation instead of runtime speech recognition
 
 Turning audio into mouth shapes is a speech-recognition problem, and I had no
 intention of doing speech recognition inside a C99 game engine. The plan
@@ -24,9 +25,9 @@ tiny text file next to the WAV, and have the engine merely *play* the result.
 The tool is [Rhubarb Lip
 Sync](https://github.com/DanielSWolf/rhubarb-lip-sync), which was built for
 exactly this — 2D adventure games — and outputs precisely the thing I need:
-not phonemes, but *mouth shapes with timestamps*. Its default recognizer wants
-English; its `phonetic` recognizer doesn't care what language it hears, it
-just matches sounds. That's what makes Italian (and any future locale) work
+not phonemes, but *mouth shapes with timestamps*. Its default recognizer
+expects English; its `phonetic` recognizer is language-independent — it matches
+sounds rather than words. That's what makes Italian (and any future locale) work
 with zero per-language setup. A new script, `tools/gen_lipsync.py`, runs it
 over every `dialog/*.wav` and writes a `.cues` sidecar in the same format
 family as the `.anim` files — one thing per line, trivially parseable:
@@ -51,9 +52,9 @@ own duration as the end of the last speech span.
 That figure is real data: the waveform of "Il cancello è chiuso…", the cue
 track Rhubarb heard in it, and a third row I'll get to at the end.
 
-## Seven mouths, drawn as three
+## Map seven phoneme shapes to three drawn mouth sprites
 
-Rhubarb speaks in six basic shapes — A through F, closed lips to puckered —
+Rhubarb outputs six basic shapes — A through F, closed lips to puckered —
 plus X for rest. So the talking animation stops being "three frames at 12
 FPS" and becomes a *character set*: one frame per shape, in a canonical order,
 with rest at index zero so a stopped animation naturally shows a closed
@@ -70,9 +71,8 @@ those three drawings:
 
 It's crude — E and F deserve their own pucker eventually — but the effect is
 immediate: the mouth shuts during pauses and between sentences, opens on the
-vowels, and generally moves *because she's saying something*, not because a
-timer is running. Real per-shape art is now a redrawn sprite sheet with no
-code change attached.
+vowels, and moves in step with the audio content, not on a fixed timer. Real
+per-shape art is now a redrawn sprite sheet with no code change attached.
 
 ## Playing cues instead of time
 
@@ -94,11 +94,11 @@ January.
 
 The parsers are deliberately strict, a lesson learned from the
 [`.anim` parser](/sdl-adventure-game/2025/01/17/parsing-animation-metadata.html)
-that trusted its input completely: out-of-order timestamps, unknown letters,
-oversized files, truncated lines — any of it rejects the whole sidecar
+that accepted its input without validation: out-of-order timestamps, unknown
+letters, oversized files, truncated lines — any of it rejects the whole sidecar
 loudly, and the line degrades to the legacy loop instead of half-working.
 
-## The motionless fox
+## No visible animation with silent placeholder audio (locale mismatch)
 
 Verification produced one good scare. The native test was green — a headless
 probe showed the frame index tracking the cue list through the whole gate
@@ -108,14 +108,13 @@ and diffed them: **nothing**. Ten identical frames. No log line either.
 
 I stared at the pipeline for a while before looking at the obvious: the
 browser's language is `en-US`, so the game had loaded the **English locale —
-whose voice lines are silent placeholder WAVs**. Rhubarb, asked what mouth
-shapes it heard in silence, had answered "closed, the whole time", and the
-engine was faithfully lip-syncing it. The system wasn't broken; it was
-working with unreasonable precision. With `?lang=it_IT` the fox spoke
-Italian, the console logged the line, and the screenshot diffs lit up exactly
-over her sprite.
+whose voice lines are silent placeholder WAVs**. Run over silent audio, Rhubarb
+had output "closed, the whole time", and the engine was faithfully lip-syncing
+that. The system wasn't broken; it was working with unreasonable precision. With
+`?lang=it_IT` the Italian voice line played, the console logged it, and the
+screenshot diffs lit up exactly over her sprite.
 
-## Words, for next time
+## Per-word timing, generated for later on-screen text
 
 The third row in the figure above is the part that isn't wired up yet. Each
 transcript now lives in a `.txt` sidecar next to its WAV (extracted from the
@@ -129,5 +128,5 @@ difference.
 Those word timings exist for the next phase: on-screen dialogue text with the
 currently spoken word highlighted, karaoke-style — partly accessibility,
 mostly because this game's audience is learning to read, and a highlight that
-moves with the voice is a reading lesson disguised as a fox. That one needs a
-font and a text renderer, so it gets its own post.
+moves with the voice helps a child connect the spoken sounds to the written
+words. That one needs a font and a text renderer, so it gets its own post.

--- a/sdl-adventure-game/_posts/2026-07-06-walking-behind-things.md
+++ b/sdl-adventure-game/_posts/2026-07-06-walking-behind-things.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "Walking Behind Things"
+title: "A Y-Sorted Action Layer for Depth Occlusion"
 ---
 
-Since the fox learned to
-[walk around things]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %}),
+Since [pathfinding gave the fox routed
+walks]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %}),
 one flatness kept bothering me: she is always *in front* of everything. Every
 scene's render function ended with the same line — draw the background, draw
 the objects, draw the fox last — so she floats over the acorn pile even when
@@ -121,5 +121,5 @@ thresholds — same feet helper, new art. The camera (Phase 3) makes the
 scene/screen split real, with scenes wider than the window and input converted
 centrally so scene code never sees camera math. And parallax planes (Phase 4)
 add a cheaper walk-behind for things the fox never stands in front of: a
-foreground strip that just draws after everything. The pile of acorns, for
-now, is the deepest thing in the game.
+foreground strip that just draws after everything. For now, the acorn pile is
+the one prop the action layer sorts against the fox.

--- a/sdl-adventure-game/_posts/2026-07-06-walking-behind-things.md
+++ b/sdl-adventure-game/_posts/2026-07-06-walking-behind-things.md
@@ -13,7 +13,7 @@ sticker on top. This post is about the smallest change that makes it read as a
 place instead: a y-sorted action layer, the first slice of a larger depth and
 camera plan.
 
-![Two screenshots of the same acorn pile: standing above it the pile overdraws the fox, walking below it the fox overdraws the pile.](/sdl-adventure-game/assets/depth-overlap-flip.png)
+![Two screenshots of the same acorn pile: standing above it the pile overdraws the fox, walking below it the fox overdraws the pile.]({{ '/sdl-adventure-game/assets/depth-overlap-flip.png' | relative_url }})
 
 ## One spec, four slices
 
@@ -53,7 +53,7 @@ float actor_feet_y(const Actor *actor);
 
 For props, there is a new type. A `Prop` doesn't own an image — it points into
 the scene's existing
-[image and animation tables](/sdl-adventure-game/2025/01/15/images-and-sprites.html),
+[image and animation tables]({% post_url /sdl-adventure-game/2025-01-15-images-and-sprites %}),
 so loading and teardown don't change at all. What it adds is the ground line,
 and a visibility flag the scene toggles:
 
@@ -84,7 +84,7 @@ lives in its own function, `action_layer_order()`, purely so the unit tests
 can assert draw orders — including that tie — without ever creating a
 renderer.
 
-![Diagram: two actors and a prop on a ground strip; the actor whose feet are above the prop's baseline is drawn first, the one below is drawn last.](/sdl-adventure-game/assets/depth-baseline-diagram.png)
+![Diagram: two actors and a prop on a ground strip; the actor whose feet are above the prop's baseline is drawn first, the one below is drawn last.]({{ '/sdl-adventure-game/assets/depth-baseline-diagram.png' | relative_url }})
 
 ## A demo with zero new art
 

--- a/sdl-adventure-game/_posts/2026-07-07-the-fox-in-the-distance.md
+++ b/sdl-adventure-game/_posts/2026-07-07-the-fox-in-the-distance.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "The Fox in the Distance"
+title: "Discrete Per-Band Sprite Variants for Distance"
 ---
 
-The fox can [walk behind
-things](/sdl-adventure-game/2026-07-06-walking-behind-things) now, but
+The fox can be drawn [behind scene
+props](/sdl-adventure-game/2026-07-06-walking-behind-things) now, but
 she's exactly the same size at the back of the playground as at the front.
 Depth cues come in pairs — occlusion says *behind*, size says *far* — and the
 game only had one of them. This post is the second slice of the depth plan
@@ -57,7 +57,7 @@ startup instead of crashing mid-stride.
 that still covers 200 pixels per second looks like she's skating; scaling the
 walk speed with the sprite keeps her apparent speed natural.
 
-## The switch you shouldn't see
+## Switching variants without a visible pop
 
 All the care in this phase is concentrated in one function:
 
@@ -127,5 +127,5 @@ through Gina's story with the extra menu button present to prove it).
 
 Next on this thread is the biggest slice: scenes wider than the window, with
 a camera that follows the fox and the scene/screen coordinate split made
-real. After that, parallax. The fox, meanwhile, knows how to be far away —
-there's a field where you can watch her do it.
+real. After that, parallax. The engine can now render the fox at a smaller size
+when she's far up the scene; there's a demo field to see it.

--- a/sdl-adventure-game/_posts/2026-07-07-the-fox-in-the-distance.md
+++ b/sdl-adventure-game/_posts/2026-07-07-the-fox-in-the-distance.md
@@ -4,14 +4,14 @@ title: "Discrete Per-Band Sprite Variants for Distance"
 ---
 
 The fox can be drawn [behind scene
-props](/sdl-adventure-game/2026-07-06-walking-behind-things) now, but
+props]({% post_url /sdl-adventure-game/2026-07-06-walking-behind-things %}) now, but
 she's exactly the same size at the back of the playground as at the front.
 Depth cues come in pairs — occlusion says *behind*, size says *far* — and the
 game only had one of them. This post is the second slice of the depth plan
 (`DEPTH_AND_CAMERA.md`): the fox reads as nearer or farther by switching
 between separately drawn sprite sets as she moves up and down the scene.
 
-![Two screenshots of the demo field: high on the lawn the fox renders from a smaller sprite set, low on the lawn from the full-size one, in front of a bush.](/sdl-adventure-game/assets/depth-variants-near-far.png)
+![Two screenshots of the demo field: high on the lawn the fox renders from a smaller sprite set, low on the lawn from the full-size one, in front of a bush.]({{ '/sdl-adventure-game/assets/depth-variants-near-far.png' | relative_url }})
 
 ## Why not just scale the sprite
 
@@ -44,7 +44,7 @@ typedef struct actor_variant_spec {
 ```
 
 The [generic
-actor](/sdl-adventure-game/2026-06-24-an-engine-for-multiple-adventures)'s
+actor]({% post_url /sdl-adventure-game/2026-06-24-an-engine-for-multiple-adventures %})'s
 animation table becomes two-dimensional — `animations[variant][state]` — and
 every lookup goes through the active variant. The fox and the hen wrap their
 existing tables in a one-element variants array, which is the whole migration:
@@ -68,7 +68,7 @@ void actor_set_variant(Actor *actor, int variant);
 The naive version — stop the old walking animation, start the new one — pops
 twice: the walk cycle restarts from frame zero, and stopping an animation
 fires its [end
-callback](/sdl-adventure-game/2026/07/01/where-should-an-animation-update-itself.html),
+callback]({% post_url /sdl-adventure-game/2026-07-01-where-should-an-animation-update-itself %}),
 which for a walk means "arrive," from the wrong place. Instead the new
 variant's current-state animation *inherits* the old one's start time, frame
 and facing, and the old one is silenced directly without going through the
@@ -103,7 +103,7 @@ actor_set_variant(fox, depth_variant_for(BANDS, LEN(BANDS),
 Scenes that never call it stay on variant 0 forever — which is every shipped
 scene today, because the far-art doesn't exist yet.
 
-![Diagram: a scene floor split by a horizontal boundary at y 520; feet above it select the far variant at 0.6 speed, feet below it the near variant at full speed.](/sdl-adventure-game/assets/depth-bands-diagram.png)
+![Diagram: a scene floor split by a horizontal boundary at y 520; feet above it select the far variant at 0.6 speed, feet below it the near variant at full speed.]({{ '/sdl-adventure-game/assets/depth-bands-diagram.png' | relative_url }})
 
 ## Placeholders until the art exists
 

--- a/sdl-adventure-game/_posts/2026-07-08-wider-than-the-window.md
+++ b/sdl-adventure-game/_posts/2026-07-08-wider-than-the-window.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Wider Than the Window"
+title: "Scenes Wider Than the Window with a Following Camera"
 ---
 
 Every scene in VaniaVolpe has been exactly one screen: 800×600, the whole
 world visible at once. That assumption was everywhere and nowhere — no line
 of code said "scene equals screen," but positions, hotspots, clicks, the
 [walk grid]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %}) and
-the renderer all quietly agreed on it. This post is about taking it apart:
+the renderer all quietly assumed it. This post is about taking it apart:
 scenes larger than the window, a camera that follows the fox, and the rule
 that made the change tractable — **scene code never does camera math**.
 
@@ -46,7 +46,7 @@ UI (the back-to-hub button), a scrolling scene's mouse events get the camera
 offset added *in place* — `event->motion.x += (int)cam->pos.x` and likewise
 for clicks — before the scene ever sees them. Every existing
 `SDL_PointInRect` hit-test, every POI walk, every cached mouse position
-downstream is suddenly operating in scene coordinates without knowing it.
+downstream is suddenly operating in scene coordinates without any change.
 Even the debug overlay's rect picker now prints scene-coordinate rectangles,
 which is exactly what you want when authoring hotspots for a wide scene.
 
@@ -86,7 +86,7 @@ don't want to watch it pan from wherever it was last week), and vertical
 scrolling falls out of the same math for free — a scene of window height just
 clamps `y` to zero forever.
 
-## The walk grid grows up
+## Resizing the walk grid to the scene
 
 The [walkability grid]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %})
 was sized to the window: 80×60 cells, hard-coded. It is now sized to the
@@ -122,5 +122,5 @@ the point: for them, this feature doesn't exist.
 
 What's left of the depth plan is the last and most visible slice: parallax
 planes — backgrounds and foregrounds scrolling at their own speeds, and the
-first real scrolling scene with art to match. The window, meanwhile, is no
-longer the world; it's just where you're looking.
+first real scrolling scene with art to match. The window is no longer the whole
+scene; it's just the visible region the camera clamps to.

--- a/sdl-adventure-game/_posts/2026-07-08-wider-than-the-window.md
+++ b/sdl-adventure-game/_posts/2026-07-08-wider-than-the-window.md
@@ -11,7 +11,7 @@ the renderer all quietly assumed it. This post is about taking it apart:
 scenes larger than the window, a camera that follows the fox, and the rule
 that made the change tractable — **scene code never does camera math**.
 
-![Two screenshots of the demo field: the fox at the west end with the east off-screen, then at the east end with the west scrolled away.](/sdl-adventure-game/assets/camera-two-ends.png)
+![Two screenshots of the demo field: the fox at the west end with the east off-screen, then at the east end with the west scrolled away.]({{ '/sdl-adventure-game/assets/camera-two-ends.png' | relative_url }})
 
 ## Two coordinate systems, one rule
 

--- a/sdl-adventure-game/_posts/2026-07-09-layers-of-distance.md
+++ b/sdl-adventure-game/_posts/2026-07-09-layers-of-distance.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Layers of Distance"
+title: "Parallax Background and Foreground Planes"
 ---
 
 The fox can walk
@@ -16,7 +16,7 @@ things race by, the far things barely move.
 
 ![The demo field at two ends: the sky is fixed, the hills have barely moved, the ground and foreground bushes have scrolled fully past.](/sdl-adventure-game/assets/parallax-two-ends.png)
 
-## One number does the whole trick
+## One number: the parallax factor
 
 A plane is almost nothing: an image, a position, and a **parallax factor**.
 
@@ -113,8 +113,8 @@ speeds behind and in front of her. The suite is at 103 checks; the two real
 adventures declare no planes and are untouched.
 
 That closes the depth plan — four independent PRs, each leaving the game
-playable, no scaling anywhere, and a fox who now lives in a world with a
-front, a back, and a horizon. What it's waiting on now is not code but
-drawings: a real, hand-authored wide location for Vania or Gina to make all of
-this carry a scene that's actually part of the story. The engine is ready for
-her; someone just has to paint the place.
+playable, no scaling anywhere, and a renderer that now composes occlusion,
+size, camera, and parallax into one consistent sense of depth. What it's waiting
+on now is not code but drawings: a real, hand-authored wide location for Vania
+or Gina to make all of this carry a scene that's actually part of the story. The
+engine is ready; someone just has to paint the place.

--- a/sdl-adventure-game/_posts/2026-07-09-layers-of-distance.md
+++ b/sdl-adventure-game/_posts/2026-07-09-layers-of-distance.md
@@ -14,7 +14,7 @@ being one flat image and becomes *layers*, each scrolling at its own speed, so
 distance reads the way it does when you look out a train window: the near
 things race by, the far things barely move.
 
-![The demo field at two ends: the sky is fixed, the hills have barely moved, the ground and foreground bushes have scrolled fully past.](/sdl-adventure-game/assets/parallax-two-ends.png)
+![The demo field at two ends: the sky is fixed, the hills have barely moved, the ground and foreground bushes have scrolled fully past.]({{ '/sdl-adventure-game/assets/parallax-two-ends.png' | relative_url }})
 
 ## One number: the parallax factor
 
@@ -37,13 +37,13 @@ behind the action. And greater than 1 slides *faster* than the scene: a
 foreground layer, nearer to the camera than the fox, that whips past as she
 walks.
 
-![Diagram of the four layers, back to front, with their parallax factors: sky 0, hills 0.4, ground 1, bushes 1.15.](/sdl-adventure-game/assets/parallax-layers-diagram.png)
+![Diagram of the four layers, back to front, with their parallax factors: sky 0, hills 0.4, ground 1, bushes 1.15.]({{ '/sdl-adventure-game/assets/parallax-layers-diagram.png' | relative_url }})
 
 The [scene struct]({% post_url /sdl-adventure-game/2026-06-24-an-engine-for-multiple-adventures %})
 carries two ordered tables — `bg_planes` drawn behind the action, `fg_planes`
 in front — and the scene declares them and nothing else. The engine loads,
 draws, and frees them, exactly like it already did for
-[scene images](/sdl-adventure-game/2025/01/15/images-and-sprites.html).
+[scene images]({% post_url /sdl-adventure-game/2025-01-15-images-and-sprites %}).
 
 ## The foreground plane is a free walk-behind
 

--- a/sdl-adventure-game/_posts/2026-07-10-read-along-with-the-fox.md
+++ b/sdl-adventure-game/_posts/2026-07-10-read-along-with-the-fox.md
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "Read Along with the Fox"
+title: "On-Screen Dialogue Text with Karaoke-Style Word Highlighting"
 ---
 
-When the fox [learned to move her mouth with the
-words](/sdl-adventure-game/2026-07-05-the-fox-learns-to-talk), the same
-spec promised a second half: the words themselves, on screen, with the one
+When the talking animation started [following mouth-shape
+cues](/sdl-adventure-game/2026-07-05-the-fox-learns-to-talk), the same
+spec called for a second half: the words themselves, on screen, with the one
 being spoken highlighted karaoke-style. Not as a debugging aid and not only as
 subtitles — as a **learn-to-read feature**. The game's audience is a child who
 can't read yet; a line of text where a bright box hops from word to word in
@@ -23,11 +23,11 @@ Every dialogue WAV has a committed `.words` sidecar estimating each word's
 start and end from the mouth cues (when speech happens) and the transcript
 (what is said). The estimate distributes words over the speech spans, so the
 highlight starts with the voice, pauses when the voice pauses, and lands
-within a word of the truth — plenty for follow-along reading. The engine just
-asks, every frame, "which word is active at this millisecond?" — a
+within a word of the truth — plenty for follow-along reading. The engine looks
+up, every frame, which word is active at the current millisecond — a
 cursor-cached lookup that was sitting in `lipsync.c` waiting for a caller.
 
-## Text, finally
+## Rendering text with SDL2_ttf
 
 This is the game's first on-screen text, which meant picking how to render
 text at all. Pre-rendered PNGs per line — the pattern the localized buttons
@@ -53,9 +53,9 @@ One robustness rule earned its keep immediately in testing: the timing file
 pairs with the displayed words *by index*, so if a transcript is edited and
 its `.words` sidecar goes stale, the counts disagree — and the overlay
 disables **just the highlight** for that line, logs once, and shows the text
-anyway. Degrade the garnish, keep the meal.
+anyway. Degrade the highlight, keep the text.
 
-## The lines you could never see
+## Showing Gina's audio-less placeholder lines
 
 My favourite consequence is the fallback. Gina's dialogue has always been a
 placeholder — her Italian lines live in the code and play as a shared silent
@@ -81,5 +81,5 @@ What remains of the speech plan is art and audio, not code: real seven-frame
 mouth sheets to replace the remapped three, and Gina's actual voice. When
 those recordings arrive, the pipeline from the first post turns them into
 cues and word timings, and everything in this post — the mouth, the text, the
-bouncing highlight — simply starts being true for her too. The fox, for now,
-reads along with herself.
+bouncing highlight — simply starts being true for her too. For now, the
+read-along text is driven entirely by the offline-generated timing.

--- a/sdl-adventure-game/_posts/2026-07-10-read-along-with-the-fox.md
+++ b/sdl-adventure-game/_posts/2026-07-10-read-along-with-the-fox.md
@@ -4,7 +4,7 @@ title: "On-Screen Dialogue Text with Karaoke-Style Word Highlighting"
 ---
 
 When the talking animation started [following mouth-shape
-cues](/sdl-adventure-game/2026-07-05-the-fox-learns-to-talk), the same
+cues]({% post_url /sdl-adventure-game/2026-07-05-the-fox-learns-to-talk %}), the same
 spec called for a second half: the words themselves, on screen, with the one
 being spoken highlighted karaoke-style. Not as a debugging aid and not only as
 subtitles — as a **learn-to-read feature**. The game's audience is a child who
@@ -12,7 +12,7 @@ can't read yet; a line of text where a bright box hops from word to word in
 time with the voice is how she starts connecting the sounds she knows to the
 shapes she doesn't. This post ships that half.
 
-![The same dialogue line photographed a second apart: the yellow highlight has moved from "Mi" to "chiave", following the voice.](/sdl-adventure-game/assets/speech-read-along.png)
+![The same dialogue line photographed a second apart: the yellow highlight has moved from "Mi" to "chiave", following the voice.]({{ '/sdl-adventure-game/assets/speech-read-along.png' | relative_url }})
 
 ## The timing was already there
 
@@ -66,7 +66,7 @@ readable in the game itself, wrapped and centred like any other — just
 without a highlight until her real recordings land and bring timing data
 with them.
 
-![Gina's placeholder line, visible in the game at last, wrapped over two centred rows.](/sdl-adventure-game/assets/speech-gina-fallback.png)
+![Gina's placeholder line, visible in the game at last, wrapped over two centred rows.]({{ '/sdl-adventure-game/assets/speech-gina-fallback.png' | relative_url }})
 
 On by default is a deliberate stance: this is an accessibility and
 learn-to-read feature, not a debugging overlay, so it ships enabled and the


### PR DESCRIPTION
Applies the owner's editorial pass to the batch of posts from 2026-06-23
onward: replace anthropomorphism of the engine, tools, and characters
(used to narrate code changes) with precise system descriptions, and
rewrite story-style titles and headings into technical descriptions.

- Titles: "The Fox Learns to Talk", "Walking Around Things", "The Fox in
  the Distance", "Wider Than the Window", "Layers of Distance", "Read
  Along with the Fox", and the animation-update post retitled to describe
  the actual change.
- Headings: story-style section headers replaced with descriptive ones
  (e.g. "Seven mouths, drawn as three" -> "Map seven phoneme shapes to
  three drawn mouth sprites").
- Prose: fox no longer "learns"/"knows how to be far away", Rhubarb
  "outputs" instead of "speaks"/"answers", parsers "accept without
  validation" instead of "trust", closing metaphors made precise.

Emscripten, engine-refactor, and one-script posts were already precise
and left unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CUcZ4F7fiWf7rmvyHysKro