### PR TITLE
Add "Tables, Not Branches" post; align post filenames/URLs with titles (with redirects)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,5 @@ kramdown:
     block:
       line_numbers: true
 source_url: https://github.com/curlybracketshq/giovanni.curlybrackets.it
+plugins:
+  - jekyll-redirect-from

--- a/sdl-adventure-game/_posts/2026-07-01-moving-animation-timing-from-render-to-update.markdown
+++ b/sdl-adventure-game/_posts/2026-07-01-moving-animation-timing-from-render-to-update.markdown
@@ -1,6 +1,8 @@
 ---
 title: "Moving Animation Timing from Render to Update"
 layout: post
+redirect_from:
+  - /sdl-adventure-game/2026/07/01/where-should-an-animation-update-itself.html
 ---
 
 {% include ai-disclaimer.html %}

--- a/sdl-adventure-game/_posts/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star.md
+++ b/sdl-adventure-game/_posts/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star.md
@@ -1,6 +1,8 @@
 ---
 layout: post
 title: "Pathfinding Around Obstacles with a Walk Grid and A*"
+redirect_from:
+  - /sdl-adventure-game/2026/07/04/walking-around-things.html
 ---
 
 {% include ai-disclaimer.html %}

--- a/sdl-adventure-game/_posts/2026-07-05-lip-sync-from-offline-generated-mouth-cues.md
+++ b/sdl-adventure-game/_posts/2026-07-05-lip-sync-from-offline-generated-mouth-cues.md
@@ -1,6 +1,8 @@
 ---
 layout: post
 title: "Lip-Sync from Offline-Generated Mouth Cues"
+redirect_from:
+  - /sdl-adventure-game/2026/07/05/the-fox-learns-to-talk.html
 ---
 
 {% include ai-disclaimer.html %}

--- a/sdl-adventure-game/_posts/2026-07-06-a-y-sorted-action-layer-for-depth-occlusion.md
+++ b/sdl-adventure-game/_posts/2026-07-06-a-y-sorted-action-layer-for-depth-occlusion.md
@@ -1,12 +1,14 @@
 ---
 layout: post
 title: "A Y-Sorted Action Layer for Depth Occlusion"
+redirect_from:
+  - /sdl-adventure-game/2026/07/06/walking-behind-things.html
 ---
 
 {% include ai-disclaimer.html %}
 
 Since [pathfinding gave the fox routed
-walks]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %}),
+walks]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %}),
 one flatness kept bothering me: she is always *in front* of everything. Every
 scene's render function ended with the same line — draw the background, draw
 the objects, draw the fox last — so she floats over the acorn pile even when
@@ -21,8 +23,8 @@ camera plan.
 
 Depth is one of three features that turned out to share a single foundation.
 The plan (drafted with Claude, like the
-[pathfinding]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %}) and
-[lip-sync]({% post_url /sdl-adventure-game/2026-07-05-the-fox-learns-to-talk %}) ones,
+[pathfinding]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %}) and
+[lip-sync]({% post_url /sdl-adventure-game/2026-07-05-lip-sync-from-offline-generated-mouth-cues %}) ones,
 and committed as `DEPTH_AND_CAMERA.md`) covers a simulated z-axis, scenes
 wider than the 800×600 window with a camera that follows the player, and
 parallax planes — and all three reduce to being careful about one distinction:
@@ -42,7 +44,7 @@ contact line is lower on the screen is nearer the viewer and gets drawn later.
 
 The engine had neither of the two numbers this needs. For the actor, the
 awkward truth is that `current_position` — the point all the
-[walk data]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %}) is
+[walk data]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %}) is
 authored against — is the sprite's *centre*, not her feet. I didn't want to
 migrate every position in every scene to a feet convention, so the two
 conventions now coexist behind one explicit helper:

--- a/sdl-adventure-game/_posts/2026-07-07-discrete-per-band-sprite-variants-for-distance.md
+++ b/sdl-adventure-game/_posts/2026-07-07-discrete-per-band-sprite-variants-for-distance.md
@@ -1,12 +1,14 @@
 ---
 layout: post
 title: "Discrete Per-Band Sprite Variants for Distance"
+redirect_from:
+  - /sdl-adventure-game/2026/07/07/the-fox-in-the-distance.html
 ---
 
 {% include ai-disclaimer.html %}
 
 The fox can be drawn [behind scene
-props]({% post_url /sdl-adventure-game/2026-07-06-walking-behind-things %}) now, but
+props]({% post_url /sdl-adventure-game/2026-07-06-a-y-sorted-action-layer-for-depth-occlusion %}) now, but
 she's exactly the same size at the back of the playground as at the front.
 Depth cues come in pairs — occlusion says *behind*, size says *far* — and the
 game only had one of them. This post is the second slice of the depth plan
@@ -70,7 +72,7 @@ void actor_set_variant(Actor *actor, int variant);
 The naive version — stop the old walking animation, start the new one — pops
 twice: the walk cycle restarts from frame zero, and stopping an animation
 fires its [end
-callback]({% post_url /sdl-adventure-game/2026-07-01-where-should-an-animation-update-itself %}),
+callback]({% post_url /sdl-adventure-game/2026-07-01-moving-animation-timing-from-render-to-update %}),
 which for a walk means "arrive," from the wrong place. Instead the new
 variant's current-state animation *inherits* the old one's start time, frame
 and facing, and the old one is silenced directly without going through the
@@ -94,7 +96,7 @@ static const DepthBand BANDS[] = {{0, 1}, {520, 0}};
 {% endraw %}
 
 Opting in is one line in the scene's update, feeding
-[`actor_feet_y`]({% post_url /sdl-adventure-game/2026-07-06-walking-behind-things %})
+[`actor_feet_y`]({% post_url /sdl-adventure-game/2026-07-06-a-y-sorted-action-layer-for-depth-occlusion %})
 into the band lookup:
 
 ```c

--- a/sdl-adventure-game/_posts/2026-07-08-scenes-wider-than-the-window-with-a-following-camera.md
+++ b/sdl-adventure-game/_posts/2026-07-08-scenes-wider-than-the-window-with-a-following-camera.md
@@ -1,6 +1,8 @@
 ---
 layout: post
 title: "Scenes Wider Than the Window with a Following Camera"
+redirect_from:
+  - /sdl-adventure-game/2026/07/08/wider-than-the-window.html
 ---
 
 {% include ai-disclaimer.html %}
@@ -8,7 +10,7 @@ title: "Scenes Wider Than the Window with a Following Camera"
 Every scene in VaniaVolpe has been exactly one screen: 800×600, the whole
 world visible at once. That assumption was everywhere and nowhere — no line
 of code said "scene equals screen," but positions, hotspots, clicks, the
-[walk grid]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %}) and
+[walk grid]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %}) and
 the renderer all quietly assumed it. This post is about taking it apart:
 scenes larger than the window, a camera that follows the fox, and the rule
 that made the change tractable — **scene code never does camera math**.
@@ -23,7 +25,7 @@ coordinates* — the pixel space of a scene's world, as big as the scene wants
 just the top-left corner of the visible window, in scene coordinates, clamped
 to the scene's bounds. Everything a scene authors — hotspots, points of
 interest, prop baselines, walk rectangles,
-[depth bands]({% post_url /sdl-adventure-game/2026-07-07-the-fox-in-the-distance %}) —
+[depth bands]({% post_url /sdl-adventure-game/2026-07-07-discrete-per-band-sprite-variants-for-distance %}) —
 stays in scene coordinates.
 
 The rule that kept this from becoming a rewrite: conversions happen in
@@ -66,7 +68,7 @@ images, so the image-level offset doesn't touch it. It now asks the renderer
 for the current offset and applies it to its scene-space drawing — walk-grid
 shading, hotspots, POIs — while its screen-space chrome (the corner markers)
 stays put. The happy consequence: the
-[walk-mask paint mode]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %})
+[walk-mask paint mode]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %})
 works across a whole scrolling scene. Walk the fox to the far end, the camera
 brings the far ground into view, and you paint it.
 
@@ -90,7 +92,7 @@ clamps `y` to zero forever.
 
 ## Resizing the walk grid to the scene
 
-The [walkability grid]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %})
+The [walkability grid]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %})
 was sized to the window: 80×60 cells, hard-coded. It is now sized to the
 scene — up to 240×120 cells for the largest scene the engine allows — and
 every algorithm on top of it (BFS nearest, A*, smoothing) was already written
@@ -98,7 +100,7 @@ against grid dimensions, so none of them changed. The A* cost array widened
 to 32 bits, because a worst-case path across a 240×120 grid can overflow 16.
 
 The satisfying part was the `.walk` mask format needing *nothing*. When the
-[paint editor]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %})
+[paint editor]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %})
 shipped, its file header — `walk 80 60` — recorded dimensions that could only
 ever be 80 and 60, a deliberate bit of planning ahead from this very spec.
 Now the header is load-bearing: masks are self-describing, the parser reads
@@ -107,7 +109,7 @@ for. Old masks stay valid byte-for-byte; the format never migrated.
 
 ## Proof, in the demo field
 
-The [demo adventure]({% post_url /sdl-adventure-game/2026-07-07-the-fox-in-the-distance %})
+The [demo adventure]({% post_url /sdl-adventure-game/2026-07-07-discrete-per-band-sprite-variants-for-distance %})
 doubled in width: a 1600×600 field, three bushes, the same two depth bands,
 and one new line — the camera. Click near the screen's edge and the fox walks
 toward ground that isn't visible yet; the camera eases after her and the far

--- a/sdl-adventure-game/_posts/2026-07-09-parallax-background-and-foreground-planes.md
+++ b/sdl-adventure-game/_posts/2026-07-09-parallax-background-and-foreground-planes.md
@@ -1,15 +1,17 @@
 ---
 layout: post
 title: "Parallax Background and Foreground Planes"
+redirect_from:
+  - /sdl-adventure-game/2026/07/09/layers-of-distance.html
 ---
 
 {% include ai-disclaimer.html %}
 
 The fox can walk
-[behind things]({% post_url /sdl-adventure-game/2026-07-06-walking-behind-things %}),
-be [far away]({% post_url /sdl-adventure-game/2026-07-07-the-fox-in-the-distance %}),
+[behind things]({% post_url /sdl-adventure-game/2026-07-06-a-y-sorted-action-layer-for-depth-occlusion %}),
+be [far away]({% post_url /sdl-adventure-game/2026-07-07-discrete-per-band-sprite-variants-for-distance %}),
 and roam a scene
-[wider than the window]({% post_url /sdl-adventure-game/2026-07-08-wider-than-the-window %}).
+[wider than the window]({% post_url /sdl-adventure-game/2026-07-08-scenes-wider-than-the-window-with-a-following-camera %}).
 This post is the last piece of that plan — parallax planes — and the one where
 all of it finally shows up in the same picture. A scene's background stops
 being one flat image and becomes *layers*, each scrolling at its own speed, so
@@ -50,7 +52,7 @@ draws, and frees them, exactly like it already did for
 ## The foreground plane is a free walk-behind
 
 The first depth post gave the fox
-[y-sorted props]({% post_url /sdl-adventure-game/2026-07-06-walking-behind-things %}) so
+[y-sorted props]({% post_url /sdl-adventure-game/2026-07-06-a-y-sorted-action-layer-for-depth-occlusion %}) so
 she could stand in front of *and* behind an object. A foreground plane is the
 cheaper cousin: a `parallax > 1` strip in front of the action layer occludes
 the actor with no prop, no baseline, no sorting. In the demo it's a row of
@@ -63,7 +65,7 @@ to pass on *either* side; planes handle the pure foreground.
 
 The render loop is a small dance, because the planes and the action layer live
 in different coordinate frames. The action layer draws through the
-[camera offset]({% post_url /sdl-adventure-game/2026-07-08-wider-than-the-window %}) set
+[camera offset]({% post_url /sdl-adventure-game/2026-07-08-scenes-wider-than-the-window-with-a-following-camera %}) set
 up in the last phase; each plane draws through *its own* offset instead. So a
 frame goes:
 
@@ -100,16 +102,16 @@ quite reconciled with itself.
 
 ## The whole plan, in one field
 
-The [demo field]({% post_url /sdl-adventure-game/2026-07-07-the-fox-in-the-distance %})
+The [demo field]({% post_url /sdl-adventure-game/2026-07-07-discrete-per-band-sprite-variants-for-distance %})
 that has grown alongside these four posts is now the proof that they compose.
 Its single flat background is gone, replaced by four planes — fixed sky,
 drifting hills, scene-locked ground, foreground bushes. Walk the fox across it
 and every feature is on screen at once: she's
-[y-sorted]({% post_url /sdl-adventure-game/2026-07-06-walking-behind-things %}) against
+[y-sorted]({% post_url /sdl-adventure-game/2026-07-06-a-y-sorted-action-layer-for-depth-occlusion %}) against
 the depth-band bushes, she
-[shrinks to a far sprite]({% post_url /sdl-adventure-game/2026-07-07-the-fox-in-the-distance %})
+[shrinks to a far sprite]({% post_url /sdl-adventure-game/2026-07-07-discrete-per-band-sprite-variants-for-distance %})
 when she climbs toward the horizon, the
-[camera follows]({% post_url /sdl-adventure-game/2026-07-08-wider-than-the-window %}) her
+[camera follows]({% post_url /sdl-adventure-game/2026-07-08-scenes-wider-than-the-window-with-a-following-camera %}) her
 across the 1600-px world, and the four layers slide past at four different
 speeds behind and in front of her. The suite is at 103 checks; the two real
 adventures declare no planes and are untouched.

--- a/sdl-adventure-game/_posts/2026-07-10-on-screen-dialogue-text-with-karaoke-style-word-highlighting.md
+++ b/sdl-adventure-game/_posts/2026-07-10-on-screen-dialogue-text-with-karaoke-style-word-highlighting.md
@@ -1,12 +1,14 @@
 ---
 layout: post
 title: "On-Screen Dialogue Text with Karaoke-Style Word Highlighting"
+redirect_from:
+  - /sdl-adventure-game/2026/07/10/read-along-with-the-fox.html
 ---
 
 {% include ai-disclaimer.html %}
 
 When the talking animation started [following mouth-shape
-cues]({% post_url /sdl-adventure-game/2026-07-05-the-fox-learns-to-talk %}), the same
+cues]({% post_url /sdl-adventure-game/2026-07-05-lip-sync-from-offline-generated-mouth-cues %}), the same
 spec called for a second half: the words themselves, on screen, with the one
 being spoken highlighted karaoke-style. Not as a debugging aid and not only as
 subtitles — as a **learn-to-read feature**. The game's audience is a child who
@@ -20,7 +22,7 @@ shapes she doesn't. This post ships that half.
 
 The hard part of a karaoke highlight is knowing *when each word is spoken* —
 and that problem was already solved offline, in the
-[first speech post]({% post_url /sdl-adventure-game/2026-07-05-the-fox-learns-to-talk %}).
+[first speech post]({% post_url /sdl-adventure-game/2026-07-05-lip-sync-from-offline-generated-mouth-cues %}).
 Every dialogue WAV has a committed `.words` sidecar estimating each word's
 start and end from the mouth cues (when speech happens) and the transcript
 (what is said). The estimate distributes words over the speech spans, so the
@@ -75,7 +77,7 @@ learn-to-read feature, not a debugging overlay, so it ships enabled and the
 *opt-out* is the setting — `--subtitles=0` on desktop, `?subtitles=0` on the
 web, plumbed exactly like the language selection. And since the overlay is
 screen-space UI, it draws after the
-[camera]({% post_url /sdl-adventure-game/2026-07-08-wider-than-the-window %}) offset is
+[camera]({% post_url /sdl-adventure-game/2026-07-08-scenes-wider-than-the-window-with-a-following-camera %}) offset is
 reset — a line reads the same whether the fox speaks it in a static room or
 at the far end of a scrolling field.
 

--- a/sdl-adventure-game/_posts/2026-07-12-tables-not-branches.md
+++ b/sdl-adventure-game/_posts/2026-07-12-tables-not-branches.md
@@ -93,7 +93,7 @@ if (hotspots_handle_click(hotspots, LEN(hotspots), fox, &walk_grid, m_pos)) {
 
 Table order *is* priority, exactly like the old chain's top-to-bottom order,
 so behaviour is unchanged by construction. The `poi` reuses the existing
-[walk-then-act machinery]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %})
+[walk-then-act machinery]({% post_url /sdl-adventure-game/2026-07-04-pathfinding-around-obstacles-with-a-walk-grid-and-a-star %})
 — an exact-goal walk with a completion callback — so the dispatcher didn't
 need any new movement code.
 

--- a/sdl-adventure-game/_posts/2026-07-12-tables-not-branches.md
+++ b/sdl-adventure-game/_posts/2026-07-12-tables-not-branches.md
@@ -1,0 +1,153 @@
+---
+layout: post
+title: "Tables, Not Branches"
+---
+
+{% include ai-disclaimer.html %}
+
+After a project health review, one refactoring stood out as worth doing right
+away: every scene in the game handled clicks with the same hand-rolled
+`if`-chain, and every scene wrote its interactions down *twice*. This post is
+about replacing those chains with a table and a twenty-line dispatcher — a
+change that lets each scene's interactions be read straight off its data.
+
+## The same shape, six times
+
+A point-and-click scene is, at heart, a list of "tapping *this region* does
+*that thing*". But in the code, each scene expressed that list as a chain of
+conditionals in its mouse handler:
+
+```c
+if (SDL_PointInRect(&m_pos, &GATE_HOTSPOT)) {
+  walk_actor_to(fox, &walk_grid, (SDL_FPoint){GATE_POI.x, GATE_POI.y},
+                true, maybe_open_gate);
+  break;
+}
+// If key has been revealed yet skip this case
+if (!has_key_been_revealed && SDL_PointInRect(&m_pos, &SHOVEL_HOTSPOT)) {
+  walk_actor_to(fox, &walk_grid, (SDL_FPoint){SHOVEL_POI.x, SHOVEL_POI.y},
+                true, maybe_dig_out_key);
+  break;
+}
+// If key hasn't been revealed yet, or if key has been picked up already,
+// then skip this case
+if (has_key_been_revealed && !has_key &&
+    SDL_PointInRect(&m_pos, &KEY_HOTSPOT)) {
+  ...
+```
+
+Six scenes across two adventures, each with three to seven of these branches,
+all the same shape: *maybe a state check, a rect test, a walk with a callback,
+break*. The comments over the state checks — "if key has been revealed yet
+skip this case" — were doing the work the code should have been doing: naming
+the rule.
+
+And there was a second copy. The [debug
+overlay]({% post_url /sdl-adventure-game/2025-01-16-debug-overlay %}) draws every
+hotspot rect, so each scene also kept an `SDL_Rect` array of its hotspots —
+listing the same regions the `if`-chain tested, with nothing tying the two
+together. Add a hotspot to the chain and forget the array, and the overlay
+shows the wrong regions.
+
+## Move the behaviour into the table
+
+The fix follows from the duplication: the rect table already exists — let it
+carry the behaviour too. A hotspot is now a struct:
+
+```c
+typedef struct hotspot {
+  SDL_Rect rect;
+  bool (*enabled)(void); // NULL = always
+  SDL_Point poi;         // where the actor walks before acting
+  bool immediate;        // fire on the click itself, no walk
+  void (*on_arrive)(void);
+} Hotspot;
+```
+
+and a scene declares its interactions as data, in its `init`:
+
+```c
+hotspots[i++] = (Hotspot){
+    .rect = GATE_HOTSPOT, .poi = GATE_POI, .on_arrive = maybe_open_gate};
+hotspots[i++] = (Hotspot){.rect = SHOVEL_HOTSPOT,
+                          .enabled = key_still_buried,
+                          .poi = SHOVEL_POI,
+                          .on_arrive = maybe_dig_out_key};
+hotspots[i++] = (Hotspot){.rect = KEY_HOTSPOT,
+                          .enabled = key_on_the_ground,
+                          .poi = KEY_POI,
+                          .on_arrive = add_key_to_inventory};
+```
+
+One dispatcher in the engine walks the table — first enabled hotspot
+containing the click wins, the actor walks to its `poi` and the callback fires
+on arrival (or immediately, for navigation arrows and buttons) — and the
+scene's mouse handler shrinks to a single question:
+
+```c
+if (hotspots_handle_click(hotspots, LEN(hotspots), fox, &walk_grid, m_pos)) {
+  break;
+}
+// Otherwise: walk to the clicked point.
+```
+
+Table order *is* priority, exactly like the old chain's top-to-bottom order,
+so behaviour is unchanged by construction. The `poi` reuses the existing
+[walk-then-act machinery]({% post_url /sdl-adventure-game/2026-07-04-walking-around-things %})
+— an exact-goal walk with a completion callback — so the dispatcher didn't
+need any new movement code.
+
+My favourite part is what happened to the state checks. `!has_key_been_revealed`
+inlined in a condition became a named predicate:
+
+```c
+static bool key_still_buried(void) { return !has_key_been_revealed; }
+```
+
+The comment that used to explain the check *is now its name*. The squirrel
+scene reads `.enabled = squirrel_has_the_peg`; the pool reads
+`.enabled = before_sunscreen`. The sunscreen bottle, which used to be one
+branch with two behaviours tangled inside, became two table entries: one
+gated on `before_sunscreen` that walks over and starts the minigame, one on
+`after_sunscreen` that just has Gina say she's already done — the same
+object meaning two things at different times, expressed as two lines.
+
+## The overlay reflects hotspot state for free
+
+Because the table now records *when* a hotspot is active, the debug overlay can
+show it: enabled hotspots draw bright, gated-off ones dim. Here is the
+playground entrance before and after digging up the key — the shovel and key
+hotspots trade places, and you can see the scene's state without clicking
+anything:
+
+![The entrance scene's debug overlay before and after digging: the key hotspot is dim until the shovel reveals it, then the shovel dims and the key brightens.]({{ '/sdl-adventure-game/assets/hotspots-overlay-flip.png' | relative_url }})
+
+That's the whole point of the single source of truth: the overlay stopped
+drawing where hotspots *are* and started drawing what a click *would actually
+do right now*. Before, that information existed only implicitly, scattered
+through the `if`-chain.
+
+## The line count went up
+
+I wrote an acceptance criterion for this task: net lines of code in the
+scenes should go down. It didn't — the diff added about thirty more lines
+than it removed. The deleted lines were dense branches; the added ones are
+named predicates, forward declarations, and one struct literal per hotspot.
+Measuring simplicity in line count misses what changed: a scene's
+interactions are now enumerable in one place, gating rules have names instead
+of comments, and the compiler-checked table replaces a convention nobody was
+checking. But the criterion was wrong and it's worth saying so plainly,
+because "the diff is red" is such a tempting proxy for "the code got simpler".
+
+Not everything was forced into the table. The playground keeps a prelude
+before the dispatch — after enough trips down the slide, *any* click ends the
+scene — and the pool keeps its fall-through where Gina refuses to leave the
+shade before her sunscreen is on. Escape hatches like these are why the
+dispatcher returns `false` instead of forcing every case through the table: a
+table for the regular cases, plain code for the two that aren't.
+
+Verification was the pleasant kind: the headless playthrough asserts the
+whole of Gina's adventure dialogue in order, and it passed byte-identical.
+The fox's chain — dig, key, gate, tree, squirrel, slide — I re-played in the
+browser, watching the overlay's dim rects light up on cue as the story
+unlocked them.


### PR DESCRIPTION
Two related changes to the AI-authored SDL adventure-game series.

## 1. New post — "Tables, Not Branches" (`2026-07-12`)

Reviewed and updated to match the series conventions:
- AI disclaimer via the shared `ai-disclaimer.html` include (renders your "written with AI assistance" wording).
- Image referenced through the `relative_url` filter.
- Inter-post links use `post_url`.
- More direct language: de-anthropomorphized a few spots and made two headings descriptive.

## 2. Filenames/URLs now match titles, with redirects

The earlier de-cutesify pass changed 8 post **titles** but left their **filenames** (and URLs) on the old slugs, so title and URL disagreed. Each file is renamed to a slug derived from its current title (same date, so only the slug changes):

| Old URL slug | New URL slug |
|---|---|
| where-should-an-animation-update-itself | moving-animation-timing-from-render-to-update |
| walking-around-things | pathfinding-around-obstacles-with-a-walk-grid-and-a-star |
| the-fox-learns-to-talk | lip-sync-from-offline-generated-mouth-cues |
| walking-behind-things | a-y-sorted-action-layer-for-depth-occlusion |
| the-fox-in-the-distance | discrete-per-band-sprite-variants-for-distance |
| wider-than-the-window | scenes-wider-than-the-window-with-a-following-camera |
| layers-of-distance | parallax-background-and-foreground-planes |
| read-along-with-the-fox | on-screen-dialogue-text-with-karaoke-style-word-highlighting |

**Retaining the old URLs:** enabled the `jekyll-redirect-from` plugin (supported on GitHub Pages) and added a `redirect_from:` entry to each renamed post. The build emits a meta-refresh + canonical redirect stub at every old path, so existing/shared links keep working. All internal `{% post_url %}` references were updated to the new filenames — and since `post_url` fails the build on a missing target, the green build confirms none were missed.

## Verification

Local `jekyll build` passes: all `post_url` references resolve, the 8 new URLs render, the 8 old URLs redirect to them, and listing pages link to the new URLs.

## Notes

- Slug for "…and A*" uses `a-star` (asterisk isn't URL-safe).
- One near-match left as-is: `one-script-two-test-frontends` vs title "One Script, Two Test Front Ends" (`frontends` vs `front-ends`). It predates this work and is cosmetic — happy to normalize it too if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUcZ4F7fiWf7rmvyHysKro