### PR TITLE
Retitle hotspots post to name the imperative→declarative change

### DIFF
--- a/sdl-adventure-game/_posts/2026-07-12-from-imperative-click-handlers-to-declarative-hotspots.md
+++ b/sdl-adventure-game/_posts/2026-07-12-from-imperative-click-handlers-to-declarative-hotspots.md
@@ -1,6 +1,8 @@
 ---
 layout: post
-title: "Tables, Not Branches"
+title: "From Imperative Click Handlers to Declarative Hotspots"
+redirect_from:
+  - /sdl-adventure-game/2026/07/12/tables-not-branches.html
 ---
 
 {% include ai-disclaimer.html %}
@@ -8,8 +10,9 @@ title: "Tables, Not Branches"
 After a project health review, one refactoring stood out as worth doing right
 away: every scene in the game handled clicks with the same hand-rolled
 `if`-chain, and every scene wrote its interactions down *twice*. This post is
-about replacing those chains with a table and a twenty-line dispatcher — a
-change that lets each scene's interactions be read straight off its data.
+about replacing those chains with a table and a twenty-line dispatcher: instead
+of *implementing* its click handling as control flow, each scene now *declares*
+its interactions as data.
 
 ## The same shape, six times
 


### PR DESCRIPTION
Follow-up to #11.

"Tables, Not Branches" didn't describe what the post is actually about. Renamed to **"From Imperative Click Handlers to Declarative Hotspots"**, which states the substance directly: each scene stops *implementing* click handling as an imperative `if`-chain and instead *declares* its interactions as data — a hotspot table (rect + enable-predicate + poi + callback) that a single generic dispatcher interprets.

Changes:
- **Title + filename** → `2026-07-12-from-imperative-click-handlers-to-declarative-hotspots.md`.
- **Redirect** from the old `…/2026/07/12/tables-not-branches.html` URL (merged in #11) to the new one, via the `jekyll-redirect-from` plugin already enabled — consistent with the other renamed posts.
- **Intro** tightened to open on the same imperative-vs-declarative framing.

Verified with a local `jekyll build`: the new URL renders with the new title, and the old `tables-not-branches` URL redirects to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUcZ4F7fiWf7rmvyHysKro

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUcZ4F7fiWf7rmvyHysKro)_